### PR TITLE
Fix for Nodejs > 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "RetroPie-profiles Login Server using Facebook Login",
   "main": "server.js",
   "scripts": {
-    "start": "n8-server --harmony-async-await retropie-profiles-server server.js"
+    "start": "n8-server retropie-profiles-server server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
NodeJs 7.6 and up automaticaly use this option, and from version 8, the argument is rejected, making the code fail.